### PR TITLE
1.1.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,8 @@
         "symfony/http-kernel": "~4.0 || ~5.0",
         "symfony/config": "~4.0 || ~5.0",
         "symfony/dependency-injection": "~4.0 || ~5.0",
-        "symfony/yaml": "~4.0 || ~5.0"
+        "symfony/yaml": "~4.0 || ~5.0",
+        "ext-sockets": "*"
     },
     "require-dev": {
         "phpunit/phpunit": "^9.0"

--- a/src/Exception/FileScanException.php
+++ b/src/Exception/FileScanException.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace Sineflow\ClamAV\Exception;
+
+class FileScanException extends \RuntimeException
+{
+    /**
+     * @var string
+     */
+    private $fileName;
+
+    /**
+     * @var string
+     */
+    private $errorMessage;
+
+    /**
+     * @param string $fileName
+     * @param string $errorMessage
+     */
+    public function __construct(string $fileName, string $errorMessage)
+    {
+        $this->fileName = $fileName;
+        $this->errorMessage = $errorMessage;
+        $message = sprintf('Error scanning "%s": %s', $fileName, $errorMessage);
+
+        parent::__construct($message);
+    }
+
+    /**
+     * @return string
+     */
+    public function getFileName(): string
+    {
+        return $this->fileName;
+    }
+
+    /**
+     * @return string
+     */
+    public function getErrorMessage(): string
+    {
+        return $this->errorMessage;
+    }
+}

--- a/src/Exception/SocketException.php
+++ b/src/Exception/SocketException.php
@@ -10,10 +10,10 @@ class SocketException extends \RuntimeException
     protected $errorCode;
 
     /**
-     * @param string $message
-     * @param int $socketErrorCode
+     * @param string   $message
+     * @param int|null $socketErrorCode
      */
-    public function __construct($message, int $socketErrorCode = null)
+    public function __construct(string $message, int $socketErrorCode = null)
     {
         $this->errorCode = $socketErrorCode;
         if ($socketErrorCode) {
@@ -27,7 +27,7 @@ class SocketException extends \RuntimeException
      * Get socket error (returned from 'socket_last_error')
      * @return int
      */
-    public function getErrorCode()
+    public function getErrorCode(): ?int
     {
         return $this->errorCode;
     }

--- a/src/ScanStrategy/AbstractScanStrategyClamdSocket.php
+++ b/src/ScanStrategy/AbstractScanStrategyClamdSocket.php
@@ -3,6 +3,7 @@
 namespace Sineflow\ClamAV\ScanStrategy;
 
 use Sineflow\ClamAV\DTO\ScannedFile;
+use Sineflow\ClamAV\Exception\FileScanException;
 use Sineflow\ClamAV\Socket\Socket;
 
 abstract class AbstractScanStrategyClamdSocket
@@ -19,8 +20,9 @@ abstract class AbstractScanStrategyClamdSocket
      */
     public function scan(string $filePath): ScannedFile
     {
+        // clamav can scan a directory, but we don't support this at the moment
         if (!is_file($filePath)) {
-            throw new \RuntimeException(sprintf('%s is not a file', $filePath));
+            throw new FileScanException($filePath, 'Not a file.');
         }
 
         $response = $this->socket->sendCommand('SCAN ' . $filePath);

--- a/tests/Files/inaccessible.txt
+++ b/tests/Files/inaccessible.txt
@@ -1,0 +1,1 @@
+Permissions for this file will be set to 000 in the beginning of the test, to make sure it's inaccessible


### PR DESCRIPTION
- Errors from clamav when scanning files now throw FileScanException or \RuntimeException if the response could not be parsed.

- Fixed reading response from socket so any errors are caught.